### PR TITLE
fix: direnv compat

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -2,10 +2,13 @@
 
 set -euo pipefail
 
-# shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
 # shellcheck source=../lib/helpers.bash
-source "$(dirname "$0")/../lib/helpers.bash"
+source "${plugin_dir}/lib/helpers.bash"
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
 
 function download() {
 	local filename="firebase"

--- a/bin/install
+++ b/bin/install
@@ -2,10 +2,13 @@
 
 set -euo pipefail
 
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
 # shellcheck source=../lib/helpers.bash
-source "$(dirname "$0")/../lib/helpers.bash"
+source "${plugin_dir}/lib/helpers.bash"
 # shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+source "${plugin_dir}/lib/utils.bash"
 
 function install_firebase() {
 	# if not asdf version with asdf_download_path then call download script here

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,10 +2,13 @@
 
 set -euo pipefail
 
-# shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
 # shellcheck source=../lib/helpers.bash
-source "$(dirname "$0")/../lib/helpers.bash"
+source "${plugin_dir}/lib/helpers.bash"
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
 
 function list_all() {
 	git ls-remote --tags --refs "$(get_github_repo)" |

--- a/bin/post-plugin-add
+++ b/bin/post-plugin-add
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
+current_script_path="${BASH_SOURCE[0]}"
+plugin_dir="$(dirname "$(dirname "$current_script_path")")"
+
 # shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+source "${plugin_dir}/lib/utils.bash"
 
 check_dependencies "$(dirname "$0")/../lib/dependencies.txt" "warning"


### PR DESCRIPTION
- [x] fix compat with `asdf-direnv` amongst other current-working-directory-sensitive tools by using script source path to build full path.

this issue was initially raised in https://github.com/jthegedus/asdf-gcloud/issues/25 and fixed in https://github.com/jthegedus/asdf-gcloud/pull/29