### PR TITLE
Adds missing argument to install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Plugin:
 
 ```shell
 # prefer the git url method
-asdf plugin add https://github.com/jthegedus/asdf-firebase.git
+asdf plugin add firebase https://github.com/jthegedus/asdf-firebase.git
 # or
 asdf plugin add firebase
 ```


### PR DESCRIPTION
The install command was missing the plugin name in the README.

## Checklist:

- [x] I have updated the documentation accordingly.
